### PR TITLE
Не убираются кнопки контроля окна при разворачивании плеера в полный экран

### DIFF
--- a/src/renderer/mixins/app/appPlatformMixin.js
+++ b/src/renderer/mixins/app/appPlatformMixin.js
@@ -66,13 +66,13 @@ export default {
 
 
   created() {
-
-    // Check if window is fullscreen
     this.setFullscreenState();
 
     // Set fullscreen events
     require('@electron/remote').getCurrentWindow().on('enter-full-screen', this.setFullscreenState);
     require('@electron/remote').getCurrentWindow().on('leave-full-screen', this.setFullscreenState);
+    require('@electron/remote').getCurrentWindow().on('enter-html-full-screen', this.setFullscreenState);
+    require('@electron/remote').getCurrentWindow().on('leave-html-full-screen', this.setFullscreenState);
   },
 
 
@@ -81,7 +81,8 @@ export default {
     // Remove fullscreen events
     require('@electron/remote').getCurrentWindow().off('enter-full-screen', this.setFullscreenState);
     require('@electron/remote').getCurrentWindow().off('leave-full-screen', this.setFullscreenState);
-
+    require('@electron/remote').getCurrentWindow().off('enter-html-full-screen', this.setFullscreenState);
+    require('@electron/remote').getCurrentWindow().off('leave-html-full-screen', this.setFullscreenState);
   }
 
 }


### PR DESCRIPTION
При просмотре серии и разворачивании просмотра на полный экран, кнопки верхнее меню (контроля окна) не скрывается. Мне кажется это не правильное поведение, во всяком случае мне это мешает)

О системе:
- Ubuntu 22.04 LTS
- Тип 64-бит
- Gnome 42.1
- Интерфейс Wayland

![image](https://user-images.githubusercontent.com/25382242/180277690-7fc1806b-c5fd-42d8-929d-383f03c2d2c4.png)

Это исправило проблему у меня.

